### PR TITLE
Fix font-family quotes in CSS

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -17,7 +17,7 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, “Segoe UI”, Roboto, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: var(--bg);
   color: var(--fg);
   height: 100vh;


### PR DESCRIPTION
## Summary
- fix invalid curly quotes in `styles.css`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ed4fbe608333a766a51d5e32c39d