### PR TITLE
Fix: Update favicon to ArielFav.png and add versioning

### DIFF
--- a/templates/Mockup.html
+++ b/templates/Mockup.html
@@ -78,6 +78,7 @@
     .node.selected { box-shadow: 0 0 0 4px gold; }
     svg polyline.selected { stroke:gold; }
   </style>
+  <link rel="icon" type="image/png" href="/static/ArielFav.png?v=3">
 </head>
 <body>
   <div class="container">

--- a/templates/Mockup2.html
+++ b/templates/Mockup2.html
@@ -58,6 +58,7 @@
     .node.selected { box-shadow:0 0 0 4px gold; }
     svg polyline.selected { stroke:gold; }
   </style>
+  <link rel="icon" type="image/png" href="/static/ArielFav.png?v=3">
 </head>
 <body>
   <div class="container">

--- a/templates/MockupLinkPartialWorking.html
+++ b/templates/MockupLinkPartialWorking.html
@@ -69,6 +69,7 @@
       stroke:#000; stroke-width:4; fill:none; cursor:pointer;
     }
   </style>
+  <link rel="icon" type="image/png" href="/static/ArielFav.png?v=3">
 </head>
 <body>
   <div class="container">

--- a/templates/Most_Recent_Lead_Edge_Cryptogrphy_Prototype.html
+++ b/templates/Most_Recent_Lead_Edge_Cryptogrphy_Prototype.html
@@ -67,6 +67,7 @@
     }
     .copy-button:hover { background-color: #218838; }
   </style>
+  <link rel="icon" type="image/png" href="/static/ArielFav.png?v=3">
 </head>
 <body>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     rel="icon"
     type="image/png"
     sizes="32x32"
-    href="/static/avatars/default.png?v=2"
+    href="/static/ArielFav.png?v=3"
   />
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">

--- a/templates/index_backup.html
+++ b/templates/index_backup.html
@@ -6,7 +6,7 @@
     rel="icon"
     type="image/png"
     sizes="32x32"
-    href="https://raw.githubusercontent.com/DART-Skyboard/Ariel/refs/heads/main/ArielWhite.png?v=2"
+    href="/static/ArielFav.png?v=3"
   />
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">

--- a/templates/index_rebuilt_with_plan_features.html
+++ b/templates/index_rebuilt_with_plan_features.html
@@ -6,7 +6,7 @@
     rel="icon"
     type="image/png"
     sizes="32x32"
-    href="https://raw.githubusercontent.com/DART-Skyboard/Ariel/refs/heads/main/ArielWhite.png?v=2"
+    href="/static/ArielFav.png?v=3"
   />
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">

--- a/templates/livemockup.html
+++ b/templates/livemockup.html
@@ -82,6 +82,7 @@
       cursor: pointer;
     }
   </style>
+  <link rel="icon" type="image/png" href="/static/ArielFav.png?v=3">
 </head>
 <body>
   <div class="container">

--- a/templates/livemockup_backup.html
+++ b/templates/livemockup_backup.html
@@ -78,6 +78,7 @@
       cursor: pointer;
     }
   </style>
+  <link rel="icon" type="image/png" href="/static/ArielFav.png?v=3">
 </head>
 <body>
   <div class="container">

--- a/templates/livemockup_final_features.html
+++ b/templates/livemockup_final_features.html
@@ -86,6 +86,7 @@
       cursor: pointer;
     }
   </style>
+  <link rel="icon" type="image/png" href="/static/ArielFav.png?v=3">
 </head>
 <body>
   <div class="container">

--- a/templates/ppreferenceform.html
+++ b/templates/ppreferenceform.html
@@ -174,6 +174,7 @@
       display: block;
     }
   </style>
+  <link rel="icon" type="image/png" href="/static/ArielFav.png?v=3">
 </head>
 <body>
   <!-- Privacy & Consent Modal -->

--- a/templates/testbkp.html
+++ b/templates/testbkp.html
@@ -6,7 +6,7 @@
     rel="icon"
     type="image/png"
     sizes="32x32"
-    href="https://raw.githubusercontent.com/DART-Skyboard/Ariel/refs/heads/main/ArielWhite.png?v=2"
+    href="/static/ArielFav.png?v=3"
   />
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">


### PR DESCRIPTION
The favicon was previously linked to /static/avatars/default.png. This commit changes all favicon links in HTML template files to use /static/ArielFav.png.

Additionally, a version query string (?v=3) has been added to the favicon URL to help prevent browser caching issues and ensure the updated favicon is displayed.