### PR TITLE
Fix: Correct button links in index.html for render.com deployment.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -614,7 +614,7 @@ touch-action: manipulation;
 <button
   id="ashCanvas"
   style="display:block; width:100%; margin:8px 0;"
-  onclick="location.href='templates/livemockup.html'"
+  onclick="location.href='/templates/livemockup.html'"
 >
   Ash Canvas
 </button>
@@ -622,7 +622,7 @@ touch-action: manipulation;
 <button
   id="leatr"
   style="display:block; width:100%; margin:8px 0;"
-  onclick="location.href='templates/LEATR.html'"
+  onclick="location.href='/templates/LEATR.html'"
 >
   Ash Tree
 </button>


### PR DESCRIPTION
The "ashCanvas" and "leatr" buttons in templates/index.html now use absolute paths for their href attributes. This ensures that the links will work correctly when the application is deployed on render.com.

- Changed `onclick="location.href='templates/livemockup.html'"` to `onclick="location.href='/templates/livemockup.html'"` for the "ashCanvas" button.
- Changed `onclick="location.href='templates/LEATR.html'"` to `onclick="location.href='/templates/LEATR.html'"` for the "leatr" button.