### PR TITLE
Feat: Add meta description and RSS link tags to HTML files

### DIFF
--- a/templates/Mockup.html
+++ b/templates/Mockup.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="description" content="A mockup page for the Autumn and Lead Edge Ash Tree Reflex project.">
+  <link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
   <title>Autumn | Lead Edge Ash Tree Reflex</title>
   <style>
     /* --- Layout --- */

--- a/templates/amino.html
+++ b/templates/amino.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
       <meta name="description" content="DART BioEdge External Explorer - Exploring Google's Alphafold | Human Amino Acid Interactive Database for Sequence Building so you may Experiment with https://alphafoldserver.com/">
+<link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
     <title>DART BioEdge External Explorer - Exploring Google's Alphafold | Human Amino Acid Interactive Database for Sequence Building</title>
     <style>
         /* General Styling */

--- a/templates/brpn.html
+++ b/templates/brpn.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
           <meta name="description" content="Lead Edge Ash Tree Reflex Neural Network [ Advanced Bouyancy Reflex Pendulum Node Prototype. ] The main Ash Tree Neural Network executable statements pass on the inner tunnel freeways within the buoyancy node piping shell, this way the Bouyancy node shell can reflex the freeway tunnel mode system(s) in the proper order of operations against all natural orders of operations.">
+<link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
     <title>Buoyancy Reflex - Batch Processing v2</title>
     <style>
         :root { --accent-color: #00e5ff; --bg-color: #121212; --panel-color: #1e1e1e; --text-color: #e0e0e0; --input-bg: #2a2a2e; }

--- a/templates/dartedgeaiide.html
+++ b/templates/dartedgeaiide.html
@@ -2,6 +2,7 @@
 <html>
 <head>
       <meta name="description" content="Ash Tree IDE *.ash Language for Lead Edge Ash Tree Reflex Neural Network to Develop Ariel NPU and Autumn AI. by: Radical Deepscale.">
+<link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
  <title>DART Edge AI IDE</title>
       <style>
       /* --- Base Layout & Theming --- */

--- a/templates/leatr.html
+++ b/templates/leatr.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta name="description" content="Lead Edge Ash Tree Reflex Neural Network As Leaf Explorer for Ariel NPU and Autumn AI by Radical Deepscale.">
+<link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
     <title>Ariel & Autumn | Lead Edge Ash Tree Reflex</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&family=Roboto:wght@300;400;700&display=swap');

--- a/templates/leatrproto.html
+++ b/templates/leatrproto.html
@@ -3,6 +3,7 @@
 <html lang="en">
 <head>
         <meta name="description" content="Lead Edge Ash Tree Reflex Neural Network Chat and Canvas for Ariel NPU and Autumn AI by Radical Deepscale.">
+<link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
     <title>Lead Edge Ash Tree Reflex [ Plaid Ash a0.0.1 ]</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/12.4.1/math.min.js"></script>
     <!-- The Sentient Journal must be loaded BEFORE the main script -->

--- a/templates/leaudiovisualizer.html
+++ b/templates/leaudiovisualizer.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta name="description" content="Originally a tutorial by [Filip Zrnzevic](https://codepen.io/filipz) on [CodePen](https://codepen.io). Then Studied and Modified to incorporate the Lead Edge Maze Ash for realtime Visual, Auditorial, and other potential Sensory connections for enhanced Logic Development in the Ash Tree Bouyancy Node. by: Radical Deepscale.">
+<link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 
     <style>

--- a/templates/livemockup.html
+++ b/templates/livemockup.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="description" content="A live mockup page for the Autumn and Lead Edge Ash Tree Reflex project.">
+  <link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
   <title>Autumn | Lead Edge Ash Tree Reflex</title>
   <style>
     body { margin:0; font-family:sans-serif; background:#f0f0f0; }

--- a/templates/mn.html
+++ b/templates/mn.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta name="description" content="Mantis Navigation For Aerospace Technology and Transportation with the incorporation of Arc Edge Finite Dynamics Measurement by Radical Deepscale.">
+<link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
     <title>Mantis Navigation</title>
     <style>
     :root {

--- a/templates/ppreferenceform.html
+++ b/templates/ppreferenceform.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="description" content="Privacy preferences form for the DART Meadow project.">
+  <link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Autumn | Lead Edge Ash Tree Reflex</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css">

--- a/templates/testbkp.html
+++ b/templates/testbkp.html
@@ -8,6 +8,8 @@
     sizes="32x32"
     href="/static/ArielFav.png?v=3"
   />
+<meta name="description" content="A test backup page for the Autumn and Lead Edge Ash Tree Reflex project.">
+<link rel="alternate" type="application/rss+xml" title="Ariel &amp; Autumn Updates" href="/feed.xml">
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 


### PR DESCRIPTION
This commit adds the proper meta description and RSS feed link tags to all HTML files in the `templates` directory.

The following files were updated:
- templates/leatr.html
- templates/brpn.html
- templates/amino.html
- templates/leatrproto.html
- templates/dartedgeaiide.html
- templates/leaudiovisualizer.html
- templates/mn.html
- templates/Mockup.html
- templates/livemockup.html
- templates/ppreferenceform.html
- templates/testbkp.html

Each of these files now includes a `<link rel="alternate" type="application/rss+xml" ...>` tag pointing to `/feed.xml`.

For the mockup and form files, a generic meta description has also been added.