### PR TITLE
Update Autumn app links

### DIFF
--- a/server.log
+++ b/server.log
@@ -1,8 +1,0 @@
- * Serving Flask app 'app'
- * Debug mode: off
-[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
- * Running on all addresses (0.0.0.0)
- * Running on http://127.0.0.1:5000
- * Running on http://192.168.0.2:5000
-[33mPress CTRL+C to quit[0m
-127.0.0.1 - - [21/Oct/2025 02:07:33] "GET / HTTP/1.1" 200 -

--- a/templates/index.html
+++ b/templates/index.html
@@ -1617,7 +1617,7 @@ DART Meadow
 
     <!-- Featured Row: Ariel (primary) + ArcLake (secondary) -->
     <div id="hp-featured-row">
-      <div class="hp-tile hp-tile-primary" onclick="location.href='/autumn.html'" title="Launch Autumn AI">
+      <div class="hp-tile hp-tile-primary" onclick="location.href='https://leatr.xyz/'" title="Launch Autumn AI">
         <div class="hp-tile-bg"></div>
         <div class="hp-tile-logo-wrap">
           <img
@@ -1679,7 +1679,7 @@ DART Meadow
 
     <!-- App Grid -->
     <div id="hp-app-grid">
-      <div class="hp-app-card" onclick="location.href='/autumn.html'">
+      <div class="hp-app-card" onclick="location.href='https://leatr.xyz/'">
         <div class="hp-app-icon">
           <img src="https://raw.githubusercontent.com/DART-Skyboard/Ariel/main/static/autumnapp.png" alt="Autumn" onerror="this.outerHTML='An'">
         </div>


### PR DESCRIPTION
Replaced the local links for the Autumn featured app tile and the Autumn app grid card in `templates/index.html` to point to `https://leatr.xyz/`.

---
*PR created automatically by Jules for task [11539154146841750075](https://jules.google.com/task/11539154146841750075) started by @dartsolarpunk*