### PR TITLE
Add Anti Meadow web app to app grid

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1839,6 +1839,11 @@ DART Meadow
         <div class="hp-app-icon"><img src="https://raw.githubusercontent.com/DART-Skyboard/Ariel/refs/heads/main/static/skinwalkerranchlogo.png" alt="SR" onerror="this.outerHTML='SR'"></div>
         <div class="hp-app-name">Skinwalker Ranch</div>
         <div class="hp-app-tag">Image</div>
+    </div>
+    <div class="hp-app-card" onclick="location.href='https://leatr.xyz/amp.html'">
+        <div class="hp-app-icon"><img src="https://raw.githubusercontent.com/DART-Skyboard/Ariel/refs/heads/main/static/amp.png" alt="AM" onerror="this.outerHTML='AM'"></div>
+        <div class="hp-app-name">Anti Meadow</div>
+        <div class="hp-app-tag">Env</div>
     </div><!-- /hp-app-grid -->
   </div><!-- /homepageSection -->
 


### PR DESCRIPTION
Adds a new web app card for "Anti Meadow" to the application grid on the homepage (`templates/index.html`). 
The new card links to `https://leatr.xyz/amp.html` and uses the specified icon from the main branch. The app has been tagged as "Env" matching the Arc Meadow style.

---
*PR created automatically by Jules for task [5322299803841087386](https://jules.google.com/task/5322299803841087386) started by @dartsolarpunk*